### PR TITLE
Lupus Wolfkin Update

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -4690,10 +4690,11 @@
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/theatre)
 "bki" = (
-/mob/living/simple_animal/pet/dog/wolfkin{
-	icon_state = "brown"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/turf/open/floor/plating/rough/cave,
+/mob/living/simple_animal/pet/dog/wolfkin/black,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/forest)
 "bkl" = (
 /obj/structure/vampdoor/camarilla,
@@ -4732,10 +4733,8 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
 "bkJ" = (
-/mob/living/simple_animal/pet/dog/wolfkin{
-	icon_state = "black"
-	},
-/turf/open/floor/plating/vampgrass,
+/mob/living/simple_animal/pet/dog/wolfkin/brown,
+/turf/open/floor/plating/rough/cave,
 /area/vtm/forest)
 "bkP" = (
 /obj/structure/railing{
@@ -15015,6 +15014,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
+/mob/living/simple_animal/pet/dog/wolfkin/ginger,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/forest)
 "dYJ" = (
@@ -56197,9 +56197,7 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/church/interior/haven)
 "pcD" = (
-/mob/living/simple_animal/pet/dog/wolfkin{
-	icon_state = "ginger"
-	},
+/mob/living/simple_animal/pet/dog/wolfkin/red,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
 "pcM" = (
@@ -67319,10 +67317,9 @@
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/tzimisce_manor)
 "rVD" = (
-/mob/living/simple_animal/pet/dog/wolfkin{
-	icon_state = "gray"
-	},
-/turf/open/floor/plating/vampdirt,
+/obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/simple_animal/pet/dog/wolfkin/gray,
+/turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
 "rVG" = (
 /obj/structure/toilet{
@@ -73000,12 +72997,6 @@
 /obj/weapon_showcase,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/shop)
-"txt" = (
-/mob/living/simple_animal/pet/dog/wolfkin{
-	icon_state = "red"
-	},
-/turf/open/floor/plating/vampdirt,
-/area/vtm/forest)
 "txy" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/fluff/hedge,
@@ -503544,8 +503535,8 @@ laE
 laE
 laE
 laE
-bki
 laE
+bkJ
 laE
 gYr
 qia
@@ -504066,8 +504057,8 @@ tyL
 sDZ
 cRj
 qia
+qia
 rVD
-gYr
 sDZ
 qia
 qia
@@ -504585,7 +504576,7 @@ qia
 sDZ
 lSY
 sDZ
-bkJ
+sDZ
 ohk
 qia
 enI
@@ -504842,7 +504833,7 @@ qia
 sDZ
 gYr
 sDZ
-ohk
+bki
 qia
 qia
 qia
@@ -506642,7 +506633,7 @@ sDZ
 sDZ
 flX
 eGF
-txt
+qia
 qia
 nrc
 tTf

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -64391,7 +64391,7 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/strip/toreador)
 "rjg" = (
-/mob/living/simple_animal/pet/dog/wolfkin,
+/mob/living/simple_animal/pet/dog/wolfkin/white,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/forest)
 "rjh" = (

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -4690,16 +4690,10 @@
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/theatre)
 "bki" = (
-/obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/corgi{
-	icon = 'code/modules/wod13/mobs.dmi';
-	icon_dead = "dog_dead";
-	icon_state = "dog";
-	name = "Lupus Wolfkin";
-	desc = "A white timber wolf.";
-	icon_living = "dog"
+/mob/living/simple_animal/pet/dog/wolfkin{
+	icon_state = "brown"
 	},
-/turf/open/floor/plating/vampgrass,
+/turf/open/floor/plating/rough/cave,
 /area/vtm/forest)
 "bkl" = (
 /obj/structure/vampdoor/camarilla,
@@ -4738,14 +4732,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
 "bkJ" = (
-/mob/living/simple_animal/pet/dog/corgi{
-	icon = 'code/modules/wod13/werewolf_lupus.dmi';
-	icon_dead = null;
-	icon_state = "white";
-	name = "Lupus Wolfkin";
-	desc = "A white timber wolf."
+/mob/living/simple_animal/pet/dog/wolfkin{
+	icon_state = "black"
 	},
-/turf/open/floor/plating/vampdirt,
+/turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
 "bkP" = (
 /obj/structure/railing{
@@ -56207,15 +56197,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/church/interior/haven)
 "pcD" = (
-/mob/living/simple_animal/pet/dog/corgi{
-	icon = 'code/modules/wod13/mobs.dmi';
-	icon_dead = "dog_dead";
-	icon_state = "dog";
-	name = "Lupus Wolfkin";
-	desc = "A white timber wolf.";
-	icon_living = "dog"
+/mob/living/simple_animal/pet/dog/wolfkin{
+	icon_state = "ginger"
 	},
-/turf/open/floor/plating/vampdirt,
+/turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
 "pcM" = (
 /obj/structure/table/wood,
@@ -64407,6 +64392,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/strip/toreador)
+"rjg" = (
+/mob/living/simple_animal/pet/dog/wolfkin,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/forest)
 "rjh" = (
 /obj/structure/table/wood,
 /obj/item/vamp/keys/children_of_gaia,
@@ -67329,6 +67318,12 @@
 	},
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/tzimisce_manor)
+"rVD" = (
+/mob/living/simple_animal/pet/dog/wolfkin{
+	icon_state = "gray"
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/forest)
 "rVG" = (
 /obj/structure/toilet{
 	dir = 8;
@@ -73006,15 +73001,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/shop)
 "txt" = (
-/mob/living/simple_animal/pet/dog/corgi{
-	icon = 'code/modules/wod13/mobs.dmi';
-	icon_dead = "dog_dead";
-	icon_state = "dog";
-	name = "Lupus Wolfkin";
-	desc = "A white timber wolf.";
-	icon_living = "dog"
+/mob/living/simple_animal/pet/dog/wolfkin{
+	icon_state = "red"
 	},
-/turf/open/floor/plating/vampgrass,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/forest)
 "txy" = (
 /obj/effect/turf_decal/siding/white,
@@ -81457,13 +81447,6 @@
 /area/vtm/pacificheights/forest)
 "vNC" = (
 /obj/structure/bed/dogbed,
-/mob/living/simple_animal/pet/dog/corgi{
-	icon = 'code/modules/wod13/werewolf_lupus.dmi';
-	icon_dead = null;
-	icon_state = "white";
-	name = "Lupus Wolfkin";
-	desc = "A white timber wolf."
-	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/forest)
 "vNI" = (
@@ -503561,7 +503544,7 @@ laE
 laE
 laE
 laE
-laE
+bki
 laE
 laE
 gYr
@@ -503829,7 +503812,7 @@ qia
 qia
 sDZ
 qia
-bkJ
+qia
 qia
 qia
 qia
@@ -504083,7 +504066,7 @@ tyL
 sDZ
 cRj
 qia
-qia
+rVD
 gYr
 sDZ
 qia
@@ -504602,7 +504585,7 @@ qia
 sDZ
 lSY
 sDZ
-sDZ
+bkJ
 ohk
 qia
 enI
@@ -505124,7 +505107,7 @@ qia
 enI
 qia
 qia
-pcD
+qia
 qia
 qia
 qia
@@ -505332,7 +505315,7 @@ sDZ
 sDZ
 sDZ
 vqi
-bki
+aEa
 aEa
 sDZ
 cjV
@@ -505628,7 +505611,7 @@ laE
 qia
 qia
 sDZ
-qia
+rjg
 eVN
 qia
 qia
@@ -506659,7 +506642,7 @@ sDZ
 sDZ
 flX
 eGF
-qia
+txt
 qia
 nrc
 tTf
@@ -507165,7 +507148,7 @@ mIV
 tyL
 laE
 sDZ
-sDZ
+pcD
 xUt
 mco
 sDZ
@@ -507949,7 +507932,7 @@ qia
 sDZ
 pte
 sDZ
-txt
+sDZ
 kOS
 tyL
 gfq

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -142,6 +142,16 @@
 	name = "McGriff"
 	desc = "This dog can tell something smells around here, and that something is CRIME!"
 
+/mob/living/simple_animal/pet/dog/wolfkin
+	name = "Lupus Wolfkin"
+	real_name = "Lupus Wolfkin"
+	desc = "It's an actual wolf."
+	icon = 'code/modules/wod13/tfn_lupus.dmi'
+	icon_state = "white"
+	butcher_results = list(/obj/item/food/meat/slab = 5)
+	limb_destroyer = 1
+	gold_core_spawnable = FRIENDLY_SPAWN
+
 /mob/living/simple_animal/pet/dog/bullterrier
 	name = "\improper bull terrier"
 	real_name = "bull terrier"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -154,21 +154,27 @@
 
 /mob/living/simple_animal/pet/dog/wolfkin/red
 	icon_state = "red"
+	icon_dead = "red_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/ginger
 	icon_state = "ginger"
+	icon_dead = "ginger_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/gray
 	icon_state = "gray"
+	icon_dead = "gray_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/white
 	icon_state = "white"
+	icon_dead = "white_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/brown
 	icon_state = "brown"
+	icon_dead = "brown_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/black
 	icon_state = "black"
+	icon_dead = "black_rest"
 
 /mob/living/simple_animal/pet/dog/bullterrier
 	name = "\improper bull terrier"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -154,27 +154,64 @@
 
 /mob/living/simple_animal/pet/dog/wolfkin/red
 	icon_state = "red"
+	base_icon_state = "red"
 	icon_dead = "red_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/ginger
 	icon_state = "ginger"
+	base_icon_state = "ginger"
 	icon_dead = "ginger_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/gray
 	icon_state = "gray"
+	base_icon_state = "gray"
 	icon_dead = "gray_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/white
 	icon_state = "white"
+	base_icon_state = "white"
 	icon_dead = "white_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/brown
 	icon_state = "brown"
+	base_icon_state = "brown"
 	icon_dead = "brown_rest"
 
 /mob/living/simple_animal/pet/dog/wolfkin/black
 	icon_state = "black"
+	base_icon_state = "black"
 	icon_dead = "black_rest"
+
+/mob/living/simple_animal/pet/dog/wolfkin/update_stat()
+    . = ..()
+    update_icons()
+
+/mob/living/simple_animal/pet/dog/wolfkin/update_icons()
+	cut_overlays()
+
+	var/laid_down = FALSE
+
+	if(stat == UNCONSCIOUS || IsSleeping() || stat == HARD_CRIT || stat == SOFT_CRIT || IsParalyzed() || stat == DEAD || body_position == LYING_DOWN)
+		icon_state = "[base_icon_state]_rest"
+		laid_down = TRUE
+	else
+		icon_state = "[base_icon_state]"
+
+	switch(getFireLoss()+getBruteLoss())
+		if(5 to 10)
+			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage1[laid_down ? "_rest" : ""]")
+			add_overlay(damage_overlay)
+		if(10 to 15)
+			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage2[laid_down ? "_rest" : ""]")
+			add_overlay(damage_overlay)
+		if(15 to INFINITY)
+			var/mutable_appearance/damage_overlay = mutable_appearance(icon, "damage3[laid_down ? "_rest" : ""]")
+			add_overlay(damage_overlay)
+
+	var/mutable_appearance/eye_overlay = mutable_appearance(icon, "eyes[laid_down ? "_rest" : ""]")
+	eye_overlay.plane = ABOVE_LIGHTING_PLANE
+	eye_overlay.layer = ABOVE_LIGHTING_LAYER
+	add_overlay(eye_overlay)
 
 /mob/living/simple_animal/pet/dog/bullterrier
 	name = "\improper bull terrier"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -152,6 +152,24 @@
 	limb_destroyer = 1
 	gold_core_spawnable = FRIENDLY_SPAWN
 
+/mob/living/simple_animal/pet/dog/wolfkin/red
+	icon_state = "red"
+
+/mob/living/simple_animal/pet/dog/wolfkin/ginger
+	icon_state = "ginger"
+
+/mob/living/simple_animal/pet/dog/wolfkin/gray
+	icon_state = "gray"
+
+/mob/living/simple_animal/pet/dog/wolfkin/white
+	icon_state = "white"
+
+/mob/living/simple_animal/pet/dog/wolfkin/brown
+	icon_state = "brown"
+
+/mob/living/simple_animal/pet/dog/wolfkin/black
+	icon_state = "black"
+
 /mob/living/simple_animal/pet/dog/bullterrier
 	name = "\improper bull terrier"
 	real_name = "bull terrier"


### PR DESCRIPTION
## About The Pull Request

Essentially what it says on the tin, adds Lupus Wolfkin as its own mob instead of being a resprited and renamed Corgi. Then swaps out the old wolfkin with the new wolfkin in the current map.


## Why It's Good For The Game

These are far higher quality sprites than the original dog ones, as they actually look like wolves now, and fixes a long known bug wherein attempting to feed a wolfkin currently will revert the name back to 'corgi'.

This also allows Garou to use the guise capability to pretend to be dogs in the city for those tribes/ronin that have the gift to do so as the npc wolves will no longer look like the dog sprite.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

<img width="1669" height="832" alt="Wolfkin in StrongDMM 2" src="https://github.com/user-attachments/assets/a6846fdc-61e8-4084-a0cd-ddabcf328e26" />

<img width="1124" height="748" alt="Wolfkin in Game" src="https://github.com/user-attachments/assets/50300b0e-a22e-4274-b951-733630af4210" />

</details>

## Changelog

:cl:

add: Added Lupus Wolfkin as its own friendly mob!
map: Removed old wolfkin corgi reskin from map
map: Added new Lupus Wolfkin to current map
code: Added lines 145 to 214 in dog.dm

/:cl:
