### PR TITLE
Round time notifications no longer sorted into deadchat

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -42,6 +42,7 @@
 #define span_engradio(str) ("<span class='engradio'>" + str + "</span>")
 #define span_extremelybig(str) ("<span class='extremelybig'>" + str + "</span>")
 #define span_ghostalert(str) ("<span class='ghostalert'>" + str + "</span>")
+#define span_ghostalertliving(str) ("<span class='ghostalertliving'>" + str + "</span>")
 #define span_gargoylealert(str) ("<span class = 'gargoylealert'>" + str + "</span>")
 #define span_green(str) ("<span class='green'>" + str + "</span>")
 #define span_greenannounce(str) ("<span class='greenannounce'>" + str + "</span>")

--- a/code/controllers/subsystem/city_time.dm
+++ b/code/controllers/subsystem/city_time.dm
@@ -59,15 +59,15 @@ SUBSYSTEM_DEF(city_time)
 
 	if(station_time_passed() > time_till_daytime - 30 MINUTES && !first_warning)
 		first_warning = TRUE
-		to_chat(world, "<span class='ghostalert'>The night is ending...</span>")
+		to_chat(world, span_ghostalertliving("The night is ending..."))
 
 	if(station_time_passed() > time_till_daytime - 15 MINUTES && !second_warning)
 		second_warning = TRUE
-		to_chat(world, "<span class='ghostalert'>First rays of the sun illuminate the sky...</span>")
+		to_chat(world, span_ghostalertliving("First rays of the sun illuminate the sky..."))
 
 	if(station_time_passed() > time_till_daytime && !daytime_started)
 		daytime_started = TRUE
-		to_chat(world, "<span class='ghostalert'>THE NIGHT IS OVER.</span>")
+		to_chat(world, span_ghostalertliving("THE NIGHT IS OVER."))
 
 	if(station_time_passed() > time_till_roundend && !roundend_started)
 		roundend_started = TRUE

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -111,6 +111,7 @@ h1.alert, h2.alert		{color: #000000;}
 .deconversion_message	{color: #5000A0;	font-size: 3;	font-style: italic;}
 
 .ghostalert				{color: #5c00e6;	font-style: italic;	font-weight: bold;}
+.ghostalertliving		{color: #5c00e6;	font-style: italic;	font-weight: bold;}
 
 .alien					{color: #543354;}
 .noticealien			{color: #00c000;}

--- a/tgui/packages/tgui-panel/chat/constants.ts
+++ b/tgui/packages/tgui-panel/chat/constants.ts
@@ -84,7 +84,7 @@ export const MESSAGE_TYPES = [
     name: 'Warnings',
     description: 'Urgent messages from the game and items',
     selector:
-      '.warning:not(.pm), .critical, .userdanger, .italics, .alertsyndie, .warningplain',
+      '.warning:not(.pm), .critical, .userdanger, .italics, .alertsyndie, .warningplain, .ghostalertliving',
   },
   {
     type: MESSAGE_TYPE_DEADCHAT,

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -735,6 +735,13 @@ mentor {
   font-weight: bold;
 }
 
+.ghostalertliving {
+  color: hsl(264, 100%, 50%);
+  font-style: italic;
+  font-weight: bold;
+}
+
+
 .alien {
   color: hsl(300, 17.7%, 44.3%);
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -748,6 +748,12 @@ h2.alert {
   font-weight: bold;
 }
 
+.ghostalertliving {
+  color: hsl(264, 100%, 45.1%);
+  font-style: italic;
+  font-weight: bold;
+}
+
 .alien {
   color: hsl(300, 24.4%, 26.5%);
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Round time notifications are now sorted into Warning instead of Deadchat. Previously, it was caught by deadchat as tgui/packages/tgui-panel/chat/constants.ts considered '.ghostalert' as deadchat. I made a new span called ghostalertliving which is visually identical but is considered as Warning. Fixes #129.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's not a deadchat message, it shouldn't be sorted as such.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<walking corpse>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: Round time notifications no longer sorted into deadchat. Now sorted into Warning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
