### PR TITLE
Sorting loose chat messages

### DIFF
--- a/code/modules/vtmb/electronics/p25.dm
+++ b/code/modules/vtmb/electronics/p25.dm
@@ -62,17 +62,17 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 			to_chat(usr, "<span class='notice'>You deactivate [src].</span>")
 			for(var/obj/item/p25radio/R in connected_radios)
 				if(R.linked_network == p25_network)
-					playsound(R, 'sound/effects/radiodestatic.ogg', 50, FALSE)
+					playsound(R, 'sound/effects/radiodestatic.ogg', 10, FALSE)
 					for(var/mob/M in get_hearers_in_view(1, get_turf(R)))
-						to_chat(M, "<span class='warning'>The [R] emits a burst of static as it loses connection to the transceiver.</span>")
+						to_chat(M, span_radio("The [R] emits a burst of static as it loses connection to the transceiver"))
 		else
 			active = TRUE
 			to_chat(usr, "<span class='notice'>You activate [src].</span>")
 			for(var/obj/item/p25radio/R in connected_radios)
 				if(R.linked_network == p25_network)
-					playsound(R, 'sound/effects/radioonn.ogg', 50, FALSE)
+					playsound(R, 'sound/effects/radioonn.ogg', 10, FALSE)
 					for(var/mob/M in get_hearers_in_view(1, get_turf(R)))
-						to_chat(M, "<span class='notice'>The [R] chirps as it establishes connection to the transceiver.</span>")
+						to_chat(M, span_radio("The [R] chirps as it establishes connection to the transceiver."))
 		update_appearance()
 
 	if(href_list["view_callsigns"])
@@ -170,8 +170,8 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 
 	message = replacetext(message, "\[<b>", "\[<b>TRANSCEIVER</b>\] \[<b>")
 
-	for(var/mob/listener in get_hearers_in_view(7, get_turf(src)))
-		to_chat(listener, message)
+	for(var/mob/listener in get_hearers_in_view(3, get_turf(src)))
+		to_chat(listener, span_radio(message))
 
 /obj/machinery/p25transceiver/proc/broadcast_to_network(message, network = src.p25_network, play_sound = 'sound/effects/radioclick.ogg', sound_volume = 30, check_dispatch = FALSE)
 	if(!active)
@@ -192,7 +192,7 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 				continue
 
 		for(var/mob/listener in get_hearers_in_view(1, get_turf(R)))
-			to_chat(listener, message)
+			to_chat(listener, span_radio(message))
 			if(play_sound)
 				playsound(R, play_sound, sound_volume, FALSE)
 

--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -450,12 +450,14 @@
 									blocked_contacts -= CNT_UNBLOCK
 				if("Call History")
 					if(phone_history_list.len > 0)
+						var/list/message_list = list()
 						for(var/datum/phonehistory/PH in phone_history_list)
 							//loop through the phone_history_list searching for a phonehistory datums and display them.
 							var/display_number_first = copytext(PH.number, 1, 4)
 							var/display_number_second = copytext(PH.number, 4, 4 + SUBSCRIBER_NUMBER_LENGTH)
 							var/split_number = display_number_first + " " + display_number_second
-							to_chat(usr, "# [PH.call_type]: [PH.name] , [split_number] at [PH.time]")
+							message_list += span_notice("[PH.call_type]: [PH.name], [split_number] at [PH.time]")
+						to_chat(usr, boxed_message(jointext(message_list, "\n")))
 					else
 						to_chat(usr, "You have no call history.") //PSEUDO_M return to fix all this
 				if("Delete Call History")

--- a/tgui/packages/tgui-panel/chat/constants.ts
+++ b/tgui/packages/tgui-panel/chat/constants.ts
@@ -56,8 +56,8 @@ export const MESSAGE_TYPES = [
   {
     type: MESSAGE_TYPE_LOCALCHAT,
     name: 'Local',
-    description: 'In-character local messages (say, emote, etc)',
-    selector: '.say, .emote',
+    description: 'In-character local messages (say, emote, subtle, etc)',
+    selector: '.say, .emote, .subtle, .subtler',
   },
   {
     type: MESSAGE_TYPE_RADIO,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
subtle is in local tab of tgui say
<img width="503" height="134" alt="image" src="https://github.com/user-attachments/assets/c1aa190b-2b92-4a84-8eea-9907db99ae8a" />

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier to tune everyone else out and erp. /j
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: subtle is sorted into local
qol: p25 radios use the radio class and are now sorted into radio
qol: 5x lowered the volume of those evil radio cackles
qol: Call history is boxed like examines
balance: you 3 tiles or closer to hear radios
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
