### PR TITLE
Mapswitch for World Icons

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,5 @@
 //#define LOWMEMORYMODE //uncomment this to load just titlescreen and runtime town
+//#define SHOW_INVENTORY_ICONS //uncomment this to make mapping software use inventory icons rather then world icons
 
 #include "map_files\generic\titlescreen.dmm"
 // #include "map_files\Mining\Lavaland.dmm"

--- a/code/__DEFINES/map_switch.dm
+++ b/code/__DEFINES/map_switch.dm
@@ -6,3 +6,21 @@
 #else
 #define MAP_SWITCH(compile_time, map_time) ##map_time
 #endif
+
+#ifdef CBT
+#define WHEN_MAP(map_time) // Not mapping, nothing here
+#else
+#define WHEN_MAP(map_time) ##map_time
+#endif
+
+#ifdef CBT
+#define WHEN_COMPILE(compile_time) ##compile_time
+#else
+#define WHEN_COMPILE(compile_time) // Not compiling, nothing here
+#endif
+
+#ifdef CBT
+#define ONFLOOR_ICON_HELPER(map_time) ##onflooricon = 'code/modules/wod13/onfloor.dmi'
+#else
+#define ONFLOOR_ICON_HELPER(map_time) // Not compiling, nothing here
+#endif

--- a/code/__DEFINES/map_switch.dm
+++ b/code/__DEFINES/map_switch.dm
@@ -3,23 +3,15 @@
 // or if map tools ever agree on a standard, this should switch to use that.
 #ifdef CBT
 #define MAP_SWITCH(compile_time, map_time) ##compile_time
-#else
-#define MAP_SWITCH(compile_time, map_time) ##map_time
-#endif
-
-#ifdef CBT
 #define WHEN_MAP(map_time) // Not mapping, nothing here
-#else
-#define WHEN_MAP(map_time) ##map_time
-#endif
-
-#ifdef CBT
 #define WHEN_COMPILE(compile_time) ##compile_time
 #else
+#define MAP_SWITCH(compile_time, map_time) ##map_time
+#define WHEN_MAP(map_time) ##map_time
 #define WHEN_COMPILE(compile_time) // Not compiling, nothing here
 #endif
 
-#ifdef CBT
+#if defined(CBT) || defined(SHOW_INVENTORY_ICONS)
 #define ONFLOOR_ICON_HELPER(file) onflooricon = ##file
 #else
 #define ONFLOOR_ICON_HELPER(file) icon=##file; onflooricon=##file

--- a/code/__DEFINES/map_switch.dm
+++ b/code/__DEFINES/map_switch.dm
@@ -20,7 +20,7 @@
 #endif
 
 #ifdef CBT
-#define ONFLOOR_ICON_HELPER(map_time) ##onflooricon = 'code/modules/wod13/onfloor.dmi'
+#define ONFLOOR_ICON_HELPER(file) onflooricon = ##file
 #else
-#define ONFLOOR_ICON_HELPER(map_time) // Not compiling, nothing here
+#define ONFLOOR_ICON_HELPER(file) icon=##file; onflooricon=##file
 #endif

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -337,30 +337,30 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/space_cigarette
 	desc = "A Space Cigarette brand cigarette."
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/dromedary
 	desc = "A DromedaryCo brand cigarette. Contrary to popular belief, does not contain Calomel, but is reported to have a watery taste."
 	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/water = 5) //camel has water
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/uplift
 	desc = "An Uplift Smooth brand cigarette. Smells refreshing."
 	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/consumable/menthol = 5)
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/robust
 	desc = "A Robust brand cigarette."
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/robustgold
 	desc = "A Robust Gold brand cigarette."
 	list_reagents = list(/datum/reagent/drug/nicotine = 15, /datum/reagent/gold = 3) // Just enough to taste a hint of expensive metal.
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/carp
 	desc = "A Carp Classic brand cigarette. A small label on its side indicates that it does NOT contain carpotoxin."
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/syndicate
 	desc = "An unknown brand cigarette."
@@ -368,17 +368,17 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 2 * 60
 	smoke_all = TRUE
 	list_reagents = list(/datum/reagent/drug/nicotine = 10, /datum/reagent/medicine/omnizine = 15)
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/shadyjims
 	desc = "A Shady Jim's Super Slims cigarette."
 	list_reagents = list(/datum/reagent/drug/nicotine = 15, /datum/reagent/toxin/plantbgone = 1, /datum/reagent/toxin = 1.5)
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/xeno
 	desc = "A Xeno Filtered brand cigarette."
 	list_reagents = list (/datum/reagent/drug/nicotine = 20, /datum/reagent/medicine/omnizine = 15)
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 // Rollies.
 
@@ -394,7 +394,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 4 * 60
 	chem_volume = 50
 	list_reagents = null
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/clothing/mask/cigarette/rollie/Initialize()
 	. = ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -3,7 +3,7 @@
 	desc = "A hand-held emergency light."
 	custom_price = PAYCHECK_EASY
 	icon = 'icons/obj/lighting.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "flashlight"
 	inhand_icon_state = "flashlight"
 	worn_icon_state = "flashlight"

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -2,7 +2,7 @@
 
 /obj/item/radio
 	icon = 'icons/obj/radio.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	name = "city bounced radio"
 	icon_state = "walkietalkie"
 	inhand_icon_state = "walkietalkie"

--- a/code/game/objects/items/dyekit.dm
+++ b/code/game/objects/items/dyekit.dm
@@ -3,7 +3,7 @@
 	desc = "A spray to dye your hair any gradients you'd like."
 	icon = 'icons/obj/dyespray.dmi'
 	icon_state = "dyespray"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/dyespray/attack_self(mob/user)
 	dye(user)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -30,7 +30,7 @@
 	worn_icon_state = "handcuff"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 0
@@ -118,7 +118,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	custom_materials = list(/datum/material/iron=150, /datum/material/glass=75)
 	breakouttime = 30 SECONDS
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/restraints/handcuffs/cable/red

--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -6,7 +6,7 @@
 	icon = 'code/modules/wod13/items.dmi'
 	lefthand_file = null
 	righthand_file = null
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_TINY
 	full_w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -20,7 +20,7 @@
 	slot_flags = ITEM_SLOT_BACK	//ERROOOOO
 	resistance_flags = NONE
 	max_integrity = 300
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	component_type = /datum/component/storage/concrete/vtm/backpack
 	body_worn = TRUE
@@ -359,7 +359,7 @@
 	desc = "A large duffel bag for holding extra things."
 	icon_state = "duffel"
 	inhand_icon_state = "duffel"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	slowdown = 1
 	component_type = /datum/component/storage/concrete/vtm/duffel
 
@@ -450,34 +450,34 @@
 	desc = "A large duffel bag for holding extra medical supplies."
 	icon_state = "duffel-med"
 	inhand_icon_state = "duffel-med"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 
 /obj/item/storage/backpack/duffelbag/med/surgery
 	name = "surgical duffel bag"
 	desc = "A large duffel bag for holding extra medical supplies - this one seems to be designed for holding surgical tools."
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/storage/backpack/duffelbag/explorer
 	name = "explorator's duffel bag"
 	desc = "A large duffel bag for holding extra exotic treasures."
 	icon_state = "duffel-explorer"
 	inhand_icon_state = "duffel-explorer"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/storage/backpack/duffelbag/hydroponics
 	name = "hydroponic's duffel bag"
 	desc = "A large duffel bag for holding extra gardening tools."
 	icon_state = "duffel-hydroponics"
 	inhand_icon_state = "duffel-hydroponics"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/storage/backpack/duffelbag/chemistry
 	name = "chemistry duffel bag"
 	desc = "A large duffel bag for holding extra chemical substances."
 	icon_state = "duffel-chemistry"
 	inhand_icon_state = "duffel-chemistry"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/storage/backpack/duffelbag/genetics
 	name = "geneticist's duffel bag"

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	name = "bible"
 	desc = "Apply to head repeatedly."
 	icon = 'icons/obj/storage.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "bible"
 	inhand_icon_state = "bible"
 	worn_icon_state = "bible"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -14,7 +14,7 @@
 	icon_state = "firstaid"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	throw_speed = 3
 	throw_range = 7
 	component_type = /datum/component/storage/concrete/vtm/firstaid
@@ -328,7 +328,7 @@
 	desc = "It's an airtight container for storing medication."
 	icon_state = "pill_canister"
 	icon = 'icons/obj/chemical.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	inhand_icon_state = "contsolid"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -361,7 +361,7 @@
 	desc = "A small stun gun designed to momentarily incapacitate assailants. To avoid continuous misfire, the button has a safety and must be pressed every few seconds."
 	icon_state = "handtaser"
 	icon = 'modular_tfn/modules/taser_tfn13/taser.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	inhand_icon_state = "emp"
 	worn_icon_state = "baton"
 	force = 1

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -3,7 +3,7 @@
 	desc = "This cuts wires."
 	icon = 'code/modules/wod13/items.dmi'
 	icon_state = "fixer"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	onflooricon_state = "fixer"
 	inhand_icon_state = "cutters"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -7,7 +7,7 @@
 	desc = "Used to remotely scan objects and biomass for DNA and fingerprints. Can show a report of the findings."
 	icon = 'code/modules/wod13/items.dmi'
 	icon_state = "magnifier"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	flags_1 = CONDUCT_1
 	item_flags = NOBLUDGEON

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -10,7 +10,7 @@
 	worn_icon_state = "camera"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	light_system = MOVABLE_LIGHT //Used as a flash here.
 	light_range = 8
 	light_color = COLOR_WHITE

--- a/code/modules/photography/camera/film.dm
+++ b/code/modules/photography/camera/film.dm
@@ -9,7 +9,7 @@
 	inhand_icon_state = "electropack"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	custom_materials = list(/datum/material/iron = 10, /datum/material/glass = 10)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -876,7 +876,7 @@
 	inhand_icon_state = "c_tube"
 	brightness = 8
 	custom_price = PAYCHECK_EASY * 0.5
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/light/tube/broken
 	status = LIGHT_BROKEN
@@ -891,7 +891,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	brightness = 4
 	custom_price = PAYCHECK_EASY * 0.4
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/light/bulb/broken
 	status = LIGHT_BROKEN

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -5,7 +5,7 @@
 	desc = "A .44 bullet casing."
 	icon = 'code/modules/wod13/ammo.dmi'
 	icon_state = "44"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	onflooricon_state = "44-1"
 	caliber = CALIBER_357
 	projectile_type = /obj/projectile/bullet/a357

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -7,7 +7,7 @@
 	icon = 'code/modules/wod13/items.dmi'
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	volume = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	item_flags = NOBLUDGEON

--- a/code/modules/vtmb/artifacts.dm
+++ b/code/modules/vtmb/artifacts.dm
@@ -27,7 +27,7 @@
 	desc = "Who knows what secrets it could contain..."
 	icon_state = "arcane"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	is_magic = TRUE
 	var/mob/living/owner

--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -37,7 +37,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 	var/registered_name
 	var/datum/bank_account/registered_account

--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -47,7 +47,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 	var/exchange_num = 415
 	var/list/contacts = list()

--- a/code/modules/vtmb/jobs/jobs.dm
+++ b/code/modules/vtmb/jobs/jobs.dm
@@ -120,7 +120,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id6"
 
@@ -133,7 +133,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id4"
 
@@ -146,7 +146,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id3"
 
@@ -159,7 +159,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id_red"
 
@@ -176,7 +176,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "bruiser_badge"
 	registered_name_is_public = FALSE
@@ -194,7 +194,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "sweeper_badge"
 	registered_name_is_public = FALSE
@@ -208,7 +208,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "emissary_badge"
 	registered_name_is_public = FALSE
@@ -222,7 +222,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "eagle_badge"
 	registered_name_is_public = FALSE
@@ -237,7 +237,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id_green"
 /* Apoc Edit
@@ -255,7 +255,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id7"
 
@@ -268,7 +268,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id7_regent"
 
@@ -281,7 +281,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id8"
 
@@ -294,7 +294,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id8"
 
@@ -307,7 +307,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id9"
 
@@ -320,7 +320,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id10"
 
@@ -333,7 +333,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id11"
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_ID
@@ -348,7 +348,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id12"
 	registered_name_is_public = FALSE
@@ -362,7 +362,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id13"
 
@@ -375,7 +375,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id_red"
 
@@ -404,7 +404,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id14"
 	registered_name_is_public = FALSE
@@ -418,7 +418,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id15"
 	registered_name_is_public = FALSE
@@ -434,7 +434,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id12"
 	registered_name_is_public = FALSE
@@ -448,7 +448,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id12"
 	registered_name_is_public = FALSE
@@ -469,7 +469,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "onyxBadge"
 
@@ -482,7 +482,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "emeraldBadge"
 
@@ -495,7 +495,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "rubyBadge"
 
@@ -509,7 +509,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id5"
 

--- a/code/modules/vtmb/magic/mysticism.dm
+++ b/code/modules/vtmb/magic/mysticism.dm
@@ -3,7 +3,7 @@
 	desc = "The secrets of Abyss Mysticism..."
 	icon_state = "mystic"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	var/list/rituals = list()
 

--- a/code/modules/vtmb/magic/pyramid.dm
+++ b/code/modules/vtmb/magic/pyramid.dm
@@ -3,7 +3,7 @@
 	desc = "The secrets of Blood Magic..."
 	icon_state = "arcane"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	is_magic = TRUE
 	var/list/rituals = list()

--- a/code/modules/vtmb/vampire_clane/tzimisce.dm
+++ b/code/modules/vtmb/vampire_clane/tzimisce.dm
@@ -243,7 +243,7 @@
 	desc = "Just blood and guts..."
 	icon_state = "guts"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/spine
@@ -251,7 +251,7 @@
 	desc = "If only I had control..."
 	icon_state = "spine"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 
 /datum/crafting_recipe/tzi_biter
@@ -503,7 +503,7 @@
 	desc = "Boghatyrskaya sila taitsa zdies'..."
 	icon_state = "dirt"
 	icon = 'code/modules/wod13/icons.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 
 /datum/material/vicissitude_flesh
@@ -541,7 +541,7 @@
 	desc = "What the fuck..."
 	singular_name = "human flesh"
 	icon_state = "human"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	mats_per_unit = list(/datum/material/vicissitude_flesh = MINERAL_MATERIAL_AMOUNT)
 	merge_type = /obj/item/stack/human_flesh
 	max_amount = 50

--- a/code/modules/vtmb/vault/drill.dm
+++ b/code/modules/vtmb/vault/drill.dm
@@ -6,7 +6,7 @@
 	inhand_icon_state = "vaultdrill"
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_HUGE
 	force = 8
 	throwforce = 10

--- a/code/modules/wod13/ammostack.dm
+++ b/code/modules/wod13/ammostack.dm
@@ -166,7 +166,7 @@
 
 /obj/item/ammo_casing/vampire
 	icon = 'code/modules/wod13/ammo.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	var/base_iconstate
 
 /obj/item/ammo_casing/vampire/c9mm
@@ -263,7 +263,7 @@
 
 /obj/item/ammo_box/vampire
 	icon = 'code/modules/wod13/ammo.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_NORMAL
 
 ///9mm/////////////

--- a/code/modules/wod13/books.dm
+++ b/code/modules/wod13/books.dm
@@ -3,7 +3,7 @@
 	desc = "So full of knowledge"
 	icon_state = "book"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	var/quote = "Hm... This book is boring."
 	COOLDOWN_DECLARE(read)

--- a/code/modules/wod13/car.dm
+++ b/code/modules/wod13/car.dm
@@ -41,7 +41,7 @@ SUBSYSTEM_DEF(carpool)
 	desc = "Stores gasoline or pure fire death."
 	icon_state = "gasoline"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/wod13/clock.dm
+++ b/code/modules/wod13/clock.dm
@@ -12,7 +12,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	slot_flags = ITEM_SLOT_GLOVES | ITEM_SLOT_ID
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	cost = 50
 
 /obj/item/cockclock/examine(mob/user)
@@ -28,7 +28,7 @@
 	icon_state = "passport1"
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_ID
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	var/closed = TRUE
 	var/owner = ""
 	var/fake = FALSE

--- a/code/modules/wod13/fishing.dm
+++ b/code/modules/wod13/fishing.dm
@@ -1,7 +1,7 @@
 /obj/item/food/fish
 	desc = "Marine life."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	eatsound = 'code/modules/wod13/sounds/eat.ogg'
 	tastes = list("fish" = 1)
@@ -32,7 +32,7 @@
 	name = "fishing rod"
 	icon_state = "fishing"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_BULKY
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'

--- a/code/modules/wod13/food.dm
+++ b/code/modules/wod13/food.dm
@@ -1,6 +1,6 @@
 /obj/item/food/vampire
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	eatsound = 'code/modules/wod13/sounds/eat.ogg'
 	custom_price = 3
@@ -52,7 +52,7 @@
 	name = "chicken wing bone"
 	icon_state = "nugget0"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/food/vampire/nugget
 	name = "chicken wing"
@@ -71,7 +71,7 @@
 	name = "chocolate bar wrapper"
 	icon_state = "bar0"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/food/vampire/bar
 	name = "chocolate bar"
@@ -105,7 +105,7 @@
 	name = "chips wrapper"
 	icon_state = "crisps0"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 /obj/item/food/vampire/crisps
 	name = "chips"
@@ -162,7 +162,7 @@
 	desc = "Careful, the beverage you're about to enjoy is extremely hot."
 	icon_state = "coffee"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	list_reagents = list(/datum/reagent/consumable/coffee = 30)
 	spillable = TRUE
 	resistance_flags = FREEZE_PROOF
@@ -178,7 +178,7 @@
 	desc = "Beer."
 	icon_state = "beer"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 30)
 	foodtype = GRAIN | ALCOHOL
 	custom_price = PAYCHECK_EASY
@@ -205,7 +205,7 @@
 	desc = "Coca cola espuma..."
 	icon_state = "colared"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	custom_price = 2
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/space_cola = 100)
@@ -236,7 +236,7 @@
 	desc = "H2O."
 	icon_state = "water1"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/water = 100)
 	age_restricted = FALSE
@@ -246,7 +246,7 @@
 	desc = "Coca cola espuma..."
 	icon_state = "colared2"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	list_reagents = list(/datum/reagent/consumable/space_cola = 50)
 	foodtype = SUGAR
 
@@ -260,7 +260,7 @@
 	desc = "More water..."
 	icon_state = "soda"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	custom_price = 3
 	list_reagents = list(/datum/reagent/consumable/sodawater = 50)
 	foodtype = SUGAR
@@ -270,7 +270,7 @@
 	desc = "More milk..."
 	icon_state = "milk"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	list_reagents = list(/datum/reagent/consumable/milk = 50)
 	fill_icon_thresholds = null
 

--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -3,7 +3,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	can_suppress = FALSE
 	recoil = 2
 
@@ -12,7 +12,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	can_suppress = FALSE
 	recoil = 2
 
@@ -128,7 +128,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "deagle"
 	ammo_type = /obj/item/ammo_casing/vampire/c44
 	caliber = CALIBER_44
@@ -167,7 +167,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "deagle"
 	ammo_type = /obj/item/ammo_casing/vampire/c50
 	caliber = CALIBER_50
@@ -190,7 +190,7 @@
 //	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 //	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "m1911"
 	ammo_type = /obj/item/ammo_casing/vampire/c45acp
 	caliber = CALIBER_45
@@ -228,7 +228,7 @@
 //	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 //	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "glock19"
 	ammo_type = /obj/item/ammo_casing/vampire/c9mm
 	caliber = CALIBER_9MM
@@ -266,7 +266,7 @@
 //	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 //	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "glock21"
 	ammo_type = /obj/item/ammo_casing/vampire/c45acp
 	caliber = CALIBER_45
@@ -340,7 +340,7 @@
 //	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 //	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "semi9mm"
 	ammo_type = /obj/item/ammo_casing/vampire/c9mm
 	caliber = CALIBER_9MM
@@ -357,7 +357,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "uzi"
 	ammo_type = /obj/item/ammo_casing/vampire/c9mm
 	caliber = CALIBER_9MM
@@ -387,7 +387,7 @@
 //	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 //	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "mp5"
 	ammo_type = /obj/item/ammo_casing/vampire/c9mm
 	caliber = CALIBER_9MM
@@ -399,6 +399,7 @@
 	desc = "A lightweight, burst-fire submachine gun, for when you really want to do some dirty cool job. Uses 9mm rounds."
 	icon_state = "mp5"
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	inhand_icon_state = "mp5"
 	worn_icon_state = "mp5"
 	mag_type = /obj/item/ammo_box/magazine/vamp9mp5
@@ -417,7 +418,7 @@
 //	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 //	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "mp7"
 	ammo_type = /obj/item/ammo_casing/vampire/c46mm
 	caliber = CALIBER_46
@@ -429,6 +430,7 @@
 	desc = "A lightweight, burst-fire submachine gun. Uses 4.6mm."
 	icon_state = "mp7"
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	inhand_icon_state = "mp7"
 	worn_icon_state = "mp7"
 	mag_type = /obj/item/ammo_box/magazine/vamp46mp7
@@ -449,7 +451,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "rifle"
 	ammo_type = /obj/item/ammo_casing/vampire/c556mm
 	caliber = CALIBER_556
@@ -465,6 +467,7 @@
 	name = "\improper AR-15 Carbine"
 	desc = "A two-round burst 5.56 toploading carbine, designated 'AR-15'."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "rifle"
 	inhand_icon_state = "rifle"
 	worn_icon_state = "rifle"
@@ -485,6 +488,7 @@
 	name = "hunting rifle"
 	desc = "A semi-automatic hunting rifle, just like what your dad used to shoot. If your dad didn't go out to get milk, anyways."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "huntrifle"
 	inhand_icon_state = "huntrifle"
 	worn_icon_state = "huntrifle"
@@ -507,7 +511,7 @@
 //	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 //	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "ak"
 	ammo_type = /obj/item/ammo_casing/vampire/c545mm
 	caliber = CALIBER_545
@@ -518,6 +522,7 @@
 	name = "\improper Kalashnikov's Automatic Rifle 74"
 	desc = "Pretty old, but also easy fireable and cleanable by vodka.Uses 5.45 rounds."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "ak74"
 	inhand_icon_state = "ak74"
 	worn_icon_state = "ak74"
@@ -541,7 +546,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "aug"
 	ammo_type = /obj/item/ammo_casing/vampire/c556mm
 	caliber = CALIBER_556
@@ -552,6 +557,7 @@
 	name = "\improper Steyr AUG-77"
 	desc = "A three-round burst 5.56 bullpup design, designated 'Steyr AUG-77'."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "aug"
 	inhand_icon_state = "aug"
 	worn_icon_state = "aug"
@@ -576,7 +582,7 @@
 //	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 //	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	ammo_type = /obj/item/ammo_casing/vampire/c45acp
 	caliber = CALIBER_45
 	max_ammo = 50
@@ -586,6 +592,7 @@
 	name = "\improper Thompson Submachine Gun"
 	desc = "\"Mamma-mia, Mercurio! Yu shot 'im in da head, he can't speek now! Yu guappo, Mercurio, yu naturale guappo!\""
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "thompson"
 	inhand_icon_state = "thompson"
 	worn_icon_state = "thompson"
@@ -615,6 +622,7 @@
 	name = "sniper rifle"
 	desc = "A long ranged weapon that does significant damage. No, you can't quickscope."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "sniper"
 	inhand_icon_state = "sniper"
 	worn_icon_state = "sniper"
@@ -647,6 +655,7 @@
 	name = "\improper HK PSG1"
 	desc = "A semi-automatic rifle that shoots 7.62 NATO and packs a solid punch, Most often used by Police Snipers '."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "PSG1"
 	inhand_icon_state = "PSG1"
 	worn_icon_state = "PSG1"
@@ -674,7 +683,7 @@
 	//lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	//righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "PSG1"
 	ammo_type = /obj/item/ammo_casing/vampire/c762x51mm
 	caliber = CALIBER_762
@@ -697,7 +706,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
 	icon_state = "pomp"
@@ -718,7 +727,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "spas15"
 	ammo_type = /obj/item/ammo_casing/vampire/c12g/buck
 	caliber = CALIBER_12G
@@ -729,6 +738,7 @@
 	name = "\improper Jaegerspas-XV"
 	desc = "A semi-automatic shotgun. It looks more like an assault rifle than a shotgun and fires at a deadly pace."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "spas15"
 	inhand_icon_state = "spas15"
 	worn_icon_state = "rifle"
@@ -754,7 +764,7 @@
 	icon = 'code/modules/wod13/48x32weapons.dmi'
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "crossbow0"
 	inhand_icon_state = "crossbow0"
 	fire_delay = 16
@@ -778,7 +788,7 @@
 	caliber = CALIBER_FOAM
 	icon_state = "arrow"
 	icon = 'code/modules/wod13/ammo.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	harmful = TRUE
 
 /datum/crafting_recipe/molotov
@@ -794,7 +804,7 @@
 	desc = "Well fire weapon."
 	icon_state = "molotov"
 	icon = 'code/modules/wod13/weapons.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	var/active = FALSE
 	masquerade_violating = TRUE
@@ -821,7 +831,7 @@
 	desc = "Well fire weapon."
 	icon_state = "flamethrower4"
 	icon = 'code/modules/wod13/weapons.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/wod13/items/argemia.dm
+++ b/code/modules/wod13/items/argemia.dm
@@ -3,7 +3,7 @@
 	desc = "Voiding..."
 	icon_state = "argemia"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/argemia/microwave_act(obj/machinery/microwave/M)

--- a/code/modules/wod13/items/clothes/eyes.dm
+++ b/code/modules/wod13/items/clothes/eyes.dm
@@ -7,7 +7,7 @@
 /obj/item/clothing/glasses/vampire
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_worn = TRUE
 
 /obj/item/clothing/glasses/vampire/yellow

--- a/code/modules/wod13/items/clothes/feet.dm
+++ b/code/modules/wod13/items/clothes/feet.dm
@@ -12,7 +12,7 @@
 	icon_state = "shoes"
 	gender = PLURAL
 	can_be_tied = FALSE
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_worn = TRUE
 	cost = 5
 

--- a/code/modules/wod13/items/clothes/hands.dm
+++ b/code/modules/wod13/items/clothes/hands.dm
@@ -7,7 +7,7 @@
 /obj/item/clothing/gloves/vampire
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	inhand_icon_state = "fingerless"
 	undyeable = TRUE
 	body_worn = TRUE

--- a/code/modules/wod13/items/clothes/head.dm
+++ b/code/modules/wod13/items/clothes/head.dm
@@ -7,7 +7,7 @@
 /obj/item/clothing/head/vampire
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 10)
 	body_worn = TRUE
 	cost = 10
@@ -279,7 +279,7 @@
 /obj/item/clothing/head/pentex
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 10)
 	body_worn = TRUE
 	cost = 10

--- a/code/modules/wod13/items/clothes/mask.dm
+++ b/code/modules/wod13/items/clothes/mask.dm
@@ -6,7 +6,7 @@
 	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	inhand_icon_state = ""
 	w_class = WEIGHT_CLASS_NORMAL
 	gas_transfer_coefficient = 0.01

--- a/code/modules/wod13/items/clothes/neck.dm
+++ b/code/modules/wod13/items/clothes/neck.dm
@@ -7,7 +7,7 @@
 /obj/item/clothing/neck/vampire
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	inhand_icon_state = ""
 	w_class = WEIGHT_CLASS_SMALL
 	body_worn = TRUE

--- a/code/modules/wod13/items/clothes/suit.dm
+++ b/code/modules/wod13/items/clothes/suit.dm
@@ -7,7 +7,7 @@
 /obj/item/clothing/suit/vampire
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 	body_parts_covered = CHEST
 	cold_protection = CHEST|GROIN
@@ -28,7 +28,7 @@
 	desc = "A set of PPE, made for working with chemicals."
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "heisenberg"
 	inhand_icon_state = "heisenberg"
 	body_parts_covered = CHEST | GROIN | ARMS
@@ -44,7 +44,7 @@
 	icon_state = "heisenberg_helm"
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_parts_covered = HEAD
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
@@ -59,7 +59,7 @@
 	icon_state = "robes"
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	inhand_icon_state = "robes"
 	flags_inv = HIDEJUMPSUIT
 	body_parts_covered = CHEST | GROIN | LEGS | ARMS
@@ -73,7 +73,7 @@
 	icon_state = "robes_hood"
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_parts_covered = HEAD
 	cold_protection = HEAD
 	flags_inv = HIDEHAIR | HIDEEARS
@@ -202,7 +202,7 @@
 	icon_state = "hoodie"
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_parts_covered = CHEST | GROIN | ARMS
 	cold_protection = CHEST | GROIN | ARMS
 	hoodtype = /obj/item/clothing/head/hooded/hood_hood
@@ -214,7 +214,7 @@
 	icon_state = "hoodie_hood"
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_parts_covered = HEAD
 	cold_protection = HEAD
 	flags_inv = HIDEHAIR | HIDEEARS
@@ -481,7 +481,7 @@
 /obj/item/clothing/suit/pentex
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_parts_covered = CHEST
 	cold_protection = CHEST|GROIN
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT

--- a/code/modules/wod13/items/clothes/under.dm
+++ b/code/modules/wod13/items/clothes/under.dm
@@ -8,7 +8,7 @@
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 15)
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_worn = TRUE
 	fitted = NO_FEMALE_UNIFORM
 	cost = 10
@@ -449,7 +449,7 @@
 	icon = 'code/modules/wod13/clothing.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 15)
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	body_worn = TRUE
 	fitted = NO_FEMALE_UNIFORM
 	cost = 10

--- a/code/modules/wod13/items/keys/keys.dm
+++ b/code/modules/wod13/items/keys/keys.dm
@@ -7,7 +7,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 	var/list/accesslocks = list(
 		"nothing"

--- a/code/modules/wod13/items/masquerade_contract.dm
+++ b/code/modules/wod13/items/masquerade_contract.dm
@@ -2,7 +2,7 @@
 	name = "\improper elegant scroll"
 	desc = "This piece of thaumaturgy shows Masquerade breakers. <b>CLICK ON the Contract to see possible breakers for catching. PUSH the target in torpor, to restore the Masquerade.</b>"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "masquerade"
 	item_flags = NOBLUDGEON
 	w_class = WEIGHT_CLASS_SMALL
@@ -46,7 +46,7 @@
 	name = "\improper brass pocketwatch"
 	desc = "The hands do not tell the time, but a spirit's blessing on this fetish points you to dangers to the veil. <b>CLICK ON the clock to see possible breakers for catching. Shame or execute the offender for crimes against the nation.</b>"
 	icon = 'icons/obj/items_and_weapons.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "pocketwatch"
 	item_flags = NOBLUDGEON
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/wod13/items/narcotics/bong.dm
+++ b/code/modules/wod13/items/narcotics/bong.dm
@@ -4,7 +4,7 @@
 	icon = 'code/modules/wod13/items.dmi'
 	icon_state = "bulbulator"
 	inhand_icon_state = "bulbulator"
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 
 	///The icon state when the bong is lit
 	var/icon_on = "bulbulator"

--- a/code/modules/wod13/items/narcotics/meth/meth.dm
+++ b/code/modules/wod13/items/narcotics/meth/meth.dm
@@ -3,7 +3,7 @@
 	desc = "Careful, the beverage you're about to enjoy is extremely hot."
 	icon_state = "package_meth"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	list_reagents = list(/datum/reagent/drug/methamphetamine = 30)
 	spillable = FALSE
 	resistance_flags = FREEZE_PROOF

--- a/code/modules/wod13/items/narcotics/weed/weed.dm
+++ b/code/modules/wod13/items/narcotics/weed/weed.dm
@@ -3,7 +3,7 @@
 	desc = "A pointy leaf commonly associated with getting absolutely blitzed."
 	icon_state = "weed"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	bite_consumption = 5
 	tastes = list("skunk" = 4, "cabbage" = 2)
 	foodtypes = VEGETABLES

--- a/code/modules/wod13/items/narcotics/weed/weedpack.dm
+++ b/code/modules/wod13/items/narcotics/weed/weedpack.dm
@@ -4,7 +4,7 @@
 	icon_state = "package_weed"
 	icon = 'code/modules/wod13/items.dmi'
 	w_class = WEIGHT_CLASS_SMALL
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	illegal = TRUE
 	cost = 150
 	//lace-able

--- a/code/modules/wod13/items/phone_book.dm
+++ b/code/modules/wod13/items/phone_book.dm
@@ -3,7 +3,7 @@
 	desc = "See the actual numbers in the city."
 	icon_state = "phonebook"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/phone_book/attack_self(mob/user)

--- a/code/modules/wod13/items/quran.dm
+++ b/code/modules/wod13/items/quran.dm
@@ -3,7 +3,7 @@
 	desc = "Inshallah..."
 	icon_state = "quran"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/quran/attack(mob/living/target, mob/living/user)

--- a/code/modules/wod13/items/ravnos.dm
+++ b/code/modules/wod13/items/ravnos.dm
@@ -3,6 +3,6 @@
 	desc = "What the..."
 	icon_state = "argemia"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	var/activated = FALSE

--- a/code/modules/wod13/map.dm
+++ b/code/modules/wod13/map.dm
@@ -305,7 +305,7 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id_red"
 
@@ -321,6 +321,6 @@
 	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id_red"

--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -2,7 +2,7 @@
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	var/quieted = FALSE
 	var/datum/weakref/owner = null
 	cost = 25
@@ -23,6 +23,7 @@
 
 /obj/item/melee/vampirearms/fireaxe
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "fireaxe0"
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
@@ -80,6 +81,7 @@
 
 /obj/item/melee/vampirearms/fireaxe/axetzi
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "axetzi0"
 	name = "living axe"
 	desc = "Truly, the weapon of a madman."
@@ -99,6 +101,7 @@
 	name = "katana"
 	desc = "An elegant weapon, its tiny edge is capable of cutting through flesh and bone with ease."
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "katana"
 	flags_1 = CONDUCT_1
 	force = 35
@@ -153,6 +156,7 @@
 	name = "rapier"
 	desc = "A thin, elegant sword, the rapier is a weapon of the duelist, designed for thrusting."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "rapier"
 	flags_1 = CONDUCT_1
 	force = 35
@@ -175,6 +179,7 @@
 	name = "machete"
 	desc = "A certified chopper fit for the jungles...but you don't see any vines around. Well-weighted enough to be thrown."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "machete"
 	flags_1 = CONDUCT_1
 	force = 25
@@ -198,6 +203,7 @@
 	name = "sabre"
 	desc = "A curved sword, the sabre is a weapon of the cavalry, designed for slashing and thrusting."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "sabre"
 	flags_1 = CONDUCT_1
 	force = 30
@@ -220,6 +226,7 @@
 	name = "longsword"
 	desc = "A classic weapon of the knight, the longsword is a versatile weapon that can be used for both cutting and thrusting."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "longsword"
 	flags_1 = CONDUCT_1
 	force = 35
@@ -242,6 +249,7 @@
 	name = "The Brother's Keeper"
 	desc = "The ancient yet classic weapon of times gone, this is a longsword. This exemplar is surprisingly well taken care of, despite its age, to the point that whatever blood or vitae it may have drawn in the past is not visible at all, while still functioning as well as it first did however long ago. Upon the flat side of this blade, a simple well-worn inscription is engraved in Latin. 'In Death, I Rise.'"
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "longsword"
 	color = "#C0C0C0"
 	flags_1 = CONDUCT_1
@@ -278,10 +286,10 @@
 	worn_icon_state = "longsword_sheathe"
 	w_class = WEIGHT_CLASS_BULKY
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	component_type = /datum/component/storage/concrete/vtm/sheathe
 
 /obj/item/storage/belt/vampire/sheathe/longsword
@@ -374,6 +382,7 @@
 	name = "baseball bat"
 	desc = "There ain't a skull in the league that can withstand a swatter."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "baseball"
 	force = 30
 	wound_bonus = 5
@@ -407,6 +416,7 @@
 	name = "tire iron"
 	desc = "Can be used as a tool or as a weapon."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "pipe"
 	force = 20
 	wound_bonus = 10
@@ -422,6 +432,7 @@
 	name = "knife"
 	desc = "Don't cut yourself accidentally."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "knife"
 	force = 30
 	wound_bonus = -5
@@ -442,6 +453,7 @@
 	name = "hand sickle"
 	desc = "Reap what they have sowed."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "handsickle"
 	force = 30
 	wound_bonus = -5
@@ -496,6 +508,7 @@
 	name = "\improper falling touch"
 	desc = "This is kind of like when you rub your feet on a shag rug so you can zap your friends, only a lot less safe."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	catchphrase = null
 	on_use_sound = 'sound/magic/disintegrate.ogg'
 	icon_state = "falling"
@@ -538,6 +551,7 @@
 	name = "chainsaw"
 	desc = "A versatile power tool. Useful for limbing trees and delimbing humans."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "chainsaw"
 	flags_1 = CONDUCT_1
 	force = 15
@@ -609,6 +623,7 @@
 	name = "stake"
 	desc = "Paralyzes blank-bodies if aimed straight to the heart."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "stake"
 	force = 10
 //	wound_bonus = -10
@@ -645,6 +660,7 @@
 
 /obj/item/melee/vampirearms/shovel
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "shovel"
 	name = "shovel"
 	desc = "Great weapon against mortal or immortal."
@@ -672,6 +688,7 @@
 	name = "scythe"
 	desc = "More instrument, than a weapon. Instrumentally cuts heads..."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "kosa"
 	force = 35
 	w_class = WEIGHT_CLASS_NORMAL
@@ -689,6 +706,7 @@
 
 /obj/item/melee/vampirearms/eguitar
 	icon = 'code/modules/wod13/48x32weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "rock0"
 	name = "electric guitar"
 	desc = "You are pretty fly for a white guy..."
@@ -756,6 +774,7 @@
 	desc = "It opens and closes."
 	icon_state = "door"
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
 	force = 20
@@ -775,6 +794,7 @@
 	name = "police baton"
 	desc = "Blunt instrument of justice."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "baton"
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb_continuous = list("bludgeons", "bashes", "beats")
@@ -839,6 +859,7 @@
 	name = "Brick"
 	desc = "Killer of gods and men alike, builder of worlds vast."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "red_brick"
 	lefthand_file = 'code/modules/wod13/lefthand.dmi'
 	righthand_file = 'code/modules/wod13/righthand.dmi'
@@ -886,6 +907,7 @@
 	name = "armblade"
 	desc = "A monstrous weapon, made out of sharpened bone."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "armblade"
 	force = 35
 	w_class = WEIGHT_CLASS_BULKY
@@ -904,6 +926,7 @@
 	name = "nematocyst whip"
 	desc = "An elongated tendril covered with stinging cells."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "lasombra"
 	damtype = TOX
 	force = 16
@@ -923,6 +946,7 @@
 	name = "electrocyte whip"
 	desc = "An elongated tendril covered with electricity generating cells."
 	icon = 'code/modules/wod13/weapons.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "lasombra"
 	damtype = BURN
 	force = 8

--- a/code/modules/wod13/postal.dm
+++ b/code/modules/wod13/postal.dm
@@ -41,7 +41,7 @@
 	name = "letter"
 	icon_state = "letter"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	var/mob/living/carbon/human/Targ
 
@@ -49,7 +49,7 @@
 	name = "letter mark"
 	icon_state = "mark"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/letter/Initialize()

--- a/code/modules/wod13/stonks.dm
+++ b/code/modules/wod13/stonks.dm
@@ -3,7 +3,7 @@
 	desc = "Contains tons of information about broker's marketplace account."
 	icon_state = "card1"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NOBLUDGEON
 	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/code/modules/wod13/witness.dm
+++ b/code/modules/wod13/witness.dm
@@ -3,7 +3,7 @@
 	desc = "911, I'm stuck in my dishwasher and stepbrother is coming in my room..."
 	icon_state = "radio"
 	icon = 'code/modules/wod13/items.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	w_class = WEIGHT_CLASS_SMALL
 	var/last_shooting = 0
 	var/last_shooting_victims = 0

--- a/modular_tfn/modules/taser_tfn13/taser_tfn13.dm
+++ b/modular_tfn/modules/taser_tfn13/taser_tfn13.dm
@@ -2,7 +2,7 @@
 	name = "V26 taser"
 	desc = "A less-than-lethal stun gun. Fires an electrode pair that will impale and electrocute noncompliant suspects. Holds two rechargable cartridges."
 	icon = 'modular_tfn/modules/taser_tfn13/taser.dmi'
-	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	ONFLOOR_ICON_HELPER('code/modules/wod13/onfloor.dmi')
 	icon_state = "taser_wod"
 	inhand_icon_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/expensive)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
mapping uses world icons instead of invetory sprites, accomplished via a define that replaces the icon folder with the onfloor icon folder when NOT complining (which means mapping)
<img width="790" height="477" alt="image" src="https://github.com/user-attachments/assets/eca79364-f712-4412-9b9c-16b3d2d923dc" />
<img width="863" height="743" alt="image" src="https://github.com/user-attachments/assets/7cb7f596-5bc8-4bd1-81fa-77891c567137" />


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
its really useful to see world icons for mapping
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
