### PR TITLE
Easier to Stop Feeding

### DIFF
--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -91,6 +91,20 @@
 				if(length(H.reagents.reagent_list))
 					if(prob(50))
 						H.reagents.trans_to(src, min(10, H.reagents.total_volume), transfered_by = mob, methods = VAMPIRE)
+		// APOC EDIT MOVE
+		if(HAS_TRAIT(src, TRAIT_ORGANOVORE))
+			mob.adjustBruteLoss(20, TRUE) // sharp teeth
+			to_chat(src, span_warning("You can't drink this disgusting <b>BLOOD</b>. Go find something meatier!"))
+			visible_message(span_danger("[src] throws up!"), span_userdanger("You throw up!"))
+			playsound(get_turf(src), 'code/modules/wod13/sounds/vomit.ogg', 75, TRUE)
+			if(isturf(loc))
+				add_splatter_floor(loc)
+			stop_sound_channel(CHANNEL_BLOOD)
+			if(client)
+				client.images -= suckbar
+			qdel(suckbar)
+			return
+
 		if(clan)
 			if(clan.name == CLAN_GIOVANNI)
 				mob.adjustBruteLoss(20, TRUE)
@@ -105,26 +119,15 @@
 					client.images -= suckbar
 				qdel(suckbar)
 				return
-		if(HAS_TRAIT(src, TRAIT_ORGANOVORE))
-			mob.adjustBruteLoss(20, TRUE) // sharp teeth
-			to_chat(src, span_warning("You can't drink this disgusting <b>BLOOD</b>. Go find something meatier!"))
-			visible_message(span_danger("[src] throws up!"), span_userdanger("You throw up!"))
-			playsound(get_turf(src), 'code/modules/wod13/sounds/vomit.ogg', 75, TRUE)
-			if(isturf(loc))
-				add_splatter_floor(loc)
-			stop_sound_channel(CHANNEL_BLOOD)
-			if(client)
-				client.images -= suckbar
-			qdel(suckbar)
-			return
-		if(clan.name == CLAN_SALUBRI_WARRIOR && (ishumanbasic(mob) || isghoul(mob))) //passes by if it's not a supernatural
-			if( (!HAS_TRAIT_FROM(mob, TRAIT_INCAPACITATED, STAMINA)) && mob.stat < SOFT_CRIT) //Needs to be KO'd to feed on
-				to_chat(src, span_warning("I HAVE NOT BESTED THIS ONE IN COMBAT!! I FEED ON WARRIORS, NOT CATTLE!!"))
-				stop_sound_channel(CHANNEL_BLOOD)
-				if(client)
-					client.images -= suckbar
-				qdel(suckbar)
-				return
+			// APOC EDIT MOVE // Salubri warrior is now with the other clan bane things
+			if(clan.name == CLAN_SALUBRI_WARRIOR && (ishumanbasic(mob) || isghoul(mob))) //passes by if it's not a supernatural
+				if( (!HAS_TRAIT_FROM(mob, TRAIT_INCAPACITATED, STAMINA)) && mob.stat < SOFT_CRIT) //Needs to be KO'd to feed on
+					to_chat(src, span_warning("I HAVE NOT BESTED THIS ONE IN COMBAT!! I FEED ON WARRIORS, NOT CATTLE!!"))
+					stop_sound_channel(CHANNEL_BLOOD)
+					if(client)
+						client.images -= suckbar
+					qdel(suckbar)
+					return
 		if(iskindred(mob))
 			to_chat(src, "<span class='userlove'>[mob]'s blood tastes HEAVENLY...</span>")
 			adjustBruteLoss(-25, TRUE)
@@ -229,9 +232,19 @@
 				client.images -= suckbar
 			qdel(suckbar)
 			return
-		if(grab_state >= GRAB_PASSIVE)
+
+		if(pulling == mob)
 			stop_sound_channel(CHANNEL_BLOOD)
 			drinksomeblood(mob)
+
+		else
+			if(client)
+				client.images -= suckbar
+			qdel(suckbar)
+			stop_sound_channel(CHANNEL_BLOOD)
+			if(!(SEND_SIGNAL(mob, COMSIG_MOB_VAMPIRE_SUCKED, mob) & COMPONENT_RESIST_VAMPIRE_KISS))
+				mob.SetSleeping(50)
+
 	else
 		if(client)
 			client.images -= suckbar


### PR DESCRIPTION

## About The Pull Request

Makes it easier to stop feeding, you can't immediately stop with this change, but it will stop feeding the next time you would usually drink blood.

Also changes a the location of when a couple of things proc, including grouping the _Salubri Warrior_ Clan Bane with the Giovanni and Toreador clan bane.

Organovore will now activate before any clan bane stuff also, making you Vomit before you get to other stuff

## Why It's Good For The Game

Being able to stop feeding a bit more consistently without shuffling around a bunch is slay.

## Changelog

:cl:
qol: made it easier to stop feeding
code: moved some feeding things around
/:cl:
