### PR TITLE
Economy quirks and starting money changes

### DIFF
--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -49,29 +49,29 @@
 	icon_state = "card2"
 	inhand_icon_state = "card2"
 	min_starting_wealth = 10000
-	max_starting_wealth = 15000
+	max_starting_wealth = 12000
 
 /obj/item/card/credit/seneschal
 	icon_state = "card2"
 	inhand_icon_state = "card2"
 	min_starting_wealth = 4000
-	max_starting_wealth = 8000
+	max_starting_wealth = 6000
 
 /obj/item/card/credit/elder
 	icon_state = "card3"
 	inhand_icon_state = "card3"
 	min_starting_wealth = 3000
-	max_starting_wealth = 7000
+	max_starting_wealth = 5000
 
 /obj/item/card/credit/giovanniboss
 	icon_state = "card2"
 	inhand_icon_state = "card2"
 	min_starting_wealth = 8000
-	max_starting_wealth = 15000
+	max_starting_wealth = 10000
 
 /obj/item/card/credit/rich
 	min_starting_wealth = 1000
-	max_starting_wealth = 4000
+	max_starting_wealth = 3000
 
 
 /obj/item/card/credit/Initialize(mapload)

--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -236,6 +236,7 @@ Dancer
 	value = -1
 	gain_text = "<span class='warning'>You feel poorer.</span>"
 	lose_text = "<span class='notice'>You feel hope for your future finances.</span>"
+	var/moneymod = 0.5
 
 /datum/quirk/debtor/add()
 	. = ..()
@@ -246,9 +247,9 @@ Dancer
 		if(debtor.account_id != account.account_id)
 			continue
 		if(debtor.clan?.name == CLAN_VENTRUE)
-			account.account_balance = 5 // Extra loss of dignitas.
+			moneymod * 1.25
 		else
-			account.account_balance = floor(account.account_balance * 0.5)
+			account.account_balance = min(floor(account.account_balance * moneymod), 20000)
 		break
 
 /datum/quirk/messy_eater

--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -247,7 +247,7 @@ Dancer
 		if(debtor.account_id != account.account_id)
 			continue
 		if(debtor.clan?.name == CLAN_VENTRUE)
-			moneymod * 1.25
+			moneymod = moneymod*1.25
 		else
 			account.account_balance = min(floor(account.account_balance * moneymod), 20000)
 		break

--- a/modular_tfn/modules/bitcoinminer/bitcoinminer.dm
+++ b/modular_tfn/modules/bitcoinminer/bitcoinminer.dm
@@ -7,8 +7,8 @@
 	var/active = FALSE
 	var/starting = FALSE
 	var/money_stored = 0
-	var/money_per_tick_min = 1
-	var/money_per_tick_max = 2
+	var/money_per_tick_min = 0.05
+	var/money_per_tick_max = 0.1
 
 /obj/machinery/bitcoin_miner/Initialize(mapload)
 	. = ..()
@@ -58,13 +58,13 @@
 	return ..()
 
 /obj/machinery/bitcoin_miner/proc/dump_loot(mob/user)
-	if(money_stored)
-		new /obj/item/stack/dollar(drop_location(), money_stored)
+	if(money_stored >= 1)
+		new /obj/item/stack/dollar(drop_location(), floor(money_stored))
 		playsound(src, 'sound/machines/eject.ogg', 30)
 		to_chat(user, span_notice("You withdraw $[money_stored] from \the [src]!"))
 		money_stored = 0
 	else
-		to_chat(user, span_notice("The balance is empty!"))
+		to_chat(user, span_notice("The balance is less than 1 dollar!"))
 
 /obj/machinery/bitcoin_miner/interact(mob/user)
 	if(!active)

--- a/modular_tfn/modules/bitcoinminer/bitcoinminer.dm
+++ b/modular_tfn/modules/bitcoinminer/bitcoinminer.dm
@@ -7,8 +7,8 @@
 	var/active = FALSE
 	var/starting = FALSE
 	var/money_stored = 0
-	var/money_per_tick_min = 0.05
-	var/money_per_tick_max = 0.1
+	var/money_per_tick_min = 1
+	var/money_per_tick_max = 2
 
 /obj/machinery/bitcoin_miner/Initialize(mapload)
 	. = ..()
@@ -58,13 +58,13 @@
 	return ..()
 
 /obj/machinery/bitcoin_miner/proc/dump_loot(mob/user)
-	if(money_stored >= 1)
-		new /obj/item/stack/dollar(drop_location(), floor(money_stored))
+	if(money_stored)
+		new /obj/item/stack/dollar(drop_location(), money_stored)
 		playsound(src, 'sound/machines/eject.ogg', 30)
 		to_chat(user, span_notice("You withdraw $[money_stored] from \the [src]!"))
 		money_stored = 0
 	else
-		to_chat(user, span_notice("The balance is less than 1 dollar!"))
+		to_chat(user, span_notice("The balance is empty!"))
 
 /obj/machinery/bitcoin_miner/interact(mob/user)
 	if(!active)

--- a/modular_zapoc/modules/apoc_quirks/deaf_quirk.dm
+++ b/modular_zapoc/modules/apoc_quirks/deaf_quirk.dm
@@ -6,6 +6,9 @@
 	lose_text = "<span class='notice'>You can hear!</span>"
 
 /datum/quirk/deaf/on_process()
+	if(!iscarbon(quirk_holder))
+		return
+
 	var/mob/living/carbon/human/H = quirk_holder
 
 	if(!(HAS_TRAIT(H, TRAIT_DEAF) && HAS_TRAIT_FROM(H, TRAIT_DEAF, "quirk")) && !istype(H.ears, /obj/item/clothing/ears/hearing_aid))

--- a/modular_zapoc/modules/apoc_quirks/money_quirks.dm
+++ b/modular_zapoc/modules/apoc_quirks/money_quirks.dm
@@ -1,0 +1,26 @@
+/datum/quirk/debtor/broke
+	name = "Broke"
+	desc = "You don't have a single dollar to your name."
+	mob_trait = TRAIT_DEBTOR
+	value = -3
+	gain_text = "<span class='warning'>You feel broke.</span>"
+	lose_text = "<span class='notice'>You feel hope for your future finances.</span>"
+	moneymod = 0
+
+/datum/quirk/debtor/rich
+	name = "Rich"
+	desc = "You made some savvy investments or maybe you were just born this way. Double your starting money. Starting balance cannot excede $20000."
+	mob_trait = TRAIT_DEBTOR
+	value = 2
+	gain_text = "<span class='warning'>You feel rich.</span>"
+	lose_text = "<span class='notice'>You feel poor.</span>"
+	moneymod = 2
+
+/datum/quirk/debtor/fabulous
+	name = "Fabulously Wealthy"
+	desc = "Money is no object to you. Triple your starting money. Starting balance cannot excede $20000."
+	mob_trait = TRAIT_DEBTOR
+	value = 5
+	gain_text = "<span class='warning'>You feel broke.</span>"
+	lose_text = "<span class='notice'>You feel hope for your future finances.</span>"
+	moneymod = 3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3775,6 +3775,7 @@
 #include "modular_zapoc\modules\apoc_quirks\bright_eyes.dm"
 #include "modular_zapoc\modules\apoc_quirks\colorblind_quirk.dm"
 #include "modular_zapoc\modules\apoc_quirks\deaf_quirk.dm"
+#include "modular_zapoc\modules\apoc_quirks\money_quirks.dm"
 #include "modular_zapoc\modules\apoc_quirks\mute_quirk.dm"
 #include "modular_zapoc\modules\apoc_quirks\talldog.dm"
 #include "modular_zapoc\modules\apoc_smites\code\truck_kun.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds three new quirks that change starting money. Broke (0 dollars, +3 points), Rich (Double Money, -2 points), and Fabulously Wealthy (Triple Money, -5 points)

These are semi-temporary pending jobcode rework and/or persistant money.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Economy is all kinds of screwy and having ways to actually delineate your character's monetary status is good for RP.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: 3 Quirks: Broke (0 dollars, +3 points), Rich (Double Money, -2 points), and Fabulously Wealthy (Triple Money, -5 points)
balance: Narrowed starting money bands such that variance is lower at the cost of lower maximum money
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
