### PR TITLE
Celerity 1 does not breach masquerade

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/celerity.dm
+++ b/code/modules/wod13/datums/powers/discipline/celerity.dm
@@ -14,15 +14,15 @@
 
 /datum/discipline_power/celerity/proc/celerity_visual(datum/discipline_power/celerity/source, atom/newloc, dir)
 	SIGNAL_HANDLER
-
-	spawn()
-		var/obj/effect/celerity/C = new(owner.loc)
-		C.name = owner.name
-		C.appearance = owner.appearance
-		C.dir = owner.dir
-		animate(C, pixel_x = rand(-16, 16), pixel_y = rand(-16, 16), alpha = 0, time = 0.5 SECONDS)
-		if(owner.CheckEyewitness(owner, owner, 7, FALSE))
-			owner.AdjustMasquerade(-1)
+	if(owner.celerity_visual)
+		spawn()
+			var/obj/effect/celerity/C = new(owner.loc)
+			C.name = owner.name
+			C.appearance = owner.appearance
+			C.dir = owner.dir
+			animate(C, pixel_x = rand(-16, 16), pixel_y = rand(-16, 16), alpha = 0, time = 0.5 SECONDS)
+			if(owner.CheckEyewitness(owner, owner, 7, FALSE))
+				owner.AdjustMasquerade(-1)
 
 /datum/discipline_power/celerity/proc/temporis_explode(datum/source, datum/discipline_power/power, atom/target)
 	SIGNAL_HANDLER
@@ -72,7 +72,7 @@
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(celerity_visual))
 
 	//put this out of its misery
-	owner.celerity_visual = TRUE
+//	owner.celerity_visual = TRUE // APOC EDIT REMOVE // It's good enough
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/celerity)
 
 /datum/discipline_power/celerity/one/deactivate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Celerity 1 now doesn't create a visual effect or violate the masquerade.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Celerity 1 does not violate the masquerade in V20 or Bloodlines. Let the vampires go fast.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Celerity 1 does not break masquerade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
