### PR TITLE
[PR FREEZE LOL] animal repulsion hotfix

### DIFF
--- a/code/modules/wod13/npcs/animal_defense.dm
+++ b/code/modules/wod13/npcs/animal_defense.dm
@@ -8,13 +8,13 @@
 		if("help")
 			if (stat == DEAD)
 				return
-			if(HAS_TRAIT(M, TRAIT_ANIMAL_REPULSION) || !has_hate) // APOC EDIT ADD
+			if(HAS_TRAIT(M, TRAIT_ANIMAL_REPULSION) && has_hate) // APOC EDIT ADD
 				playsound(src, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 				var/shove_dir = get_dir(M, src)
 				if(!M.client)
 					Move(get_step(src, shove_dir), shove_dir)
-				visible_message("<span class='notice'>[M] shies away from [src], baring teeth!</span>", \
-								"<span class='notice'>[M] feels <b>deeply uncomfortable</b> as they reach for you. You instinctively bare your teeth!</span>", null, null, M)
+				visible_message("<span class='notice'>[src] shies away from [M], baring teeth!</span>", \
+								"<span class='notice'>[M] makes you feel <b>deeply uncomfortable</b> as they reach for you. You instinctively bare your teeth!</span>", null, null, M)
 				to_chat(M, "<span class='notice'>You attempt to [response_help_simple] [src], but they shy from you, baring teeth.</span>")
 				return TRUE
 			visible_message("<span class='notice'>[M] [response_help_continuous] [src].</span>", \
@@ -26,15 +26,15 @@
 
 		if("grab")
 			grabbedby(M)
-			if(HAS_TRAIT(M, TRAIT_ANIMAL_REPULSION) || !has_hate) // APOC EDIT ADD
+			if(HAS_TRAIT(M, TRAIT_ANIMAL_REPULSION) && has_hate) // APOC EDIT ADD
 				if (stat == DEAD)
 					return
 				playsound(src, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 				var/shove_dir = get_dir(M, src)
 				if(!M.client)
 					Move(get_step(src, shove_dir), shove_dir)
-				visible_message("<span class='notice'>[M] shies away from [src], baring teeth!</span>", \
-								"<span class='notice'>[M] feels <b>deeply uncomfortable</b> as they reach for you. You instinctively bare your teeth!</span>", null, null, M)
+				visible_message("<span class='notice'>[src] shies away from [M], baring teeth!</span>", \
+								"<span class='notice'>[M] makes you feel <b>deeply uncomfortable</b> as they reach for you. You instinctively bare your teeth!</span>", null, null, M)
 				to_chat(M, "<span class='notice'>You attempt to grab [src], but they shy from you, baring teeth.</span>")
 				return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
quirk breaking bug and text nits fix
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details open>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: no more animal repulsion edgecases
spellcheck: the message for animal repulsion in right order lol
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
