### PR TITLE
bright eyes bugfix

### DIFF
--- a/modular_zapoc/modules/apoc_quirks/code/bright_eyes.dm
+++ b/modular_zapoc/modules/apoc_quirks/code/bright_eyes.dm
@@ -2,6 +2,7 @@
 	name = "Bright Eyes"
 	desc = "Your eyes are a startling color or bear some other characteristic that is odd to observers. Contacts? Weird Genes? Born a wolf? Who can say. Maybe wear some sunglasses."
 	value = 0
+	mob_trait = TRAIT_BRIGHTEYES
 	gain_text = "<span class='warning'>Your eyes feel unique.</span>"
 	lose_text = "<span class='notice'>Your eyes feel generic.</span>"
 	allowed_species = list("Ghoul","Human","Imbued","Vampire","Kuei-Jin")
@@ -10,5 +11,4 @@
 	name = "Bright Eyes (Fera)"
 	desc = "To those who know, your eyes betray your true nature. Your eyes are a startling color or characteristically canine in apperance."
 	value = -1
-	mob_trait = TRAIT_BRIGHTEYES
 	allowed_species = list("Werewolf")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
contribute to darkpack https://github.com/DarkPack13/SecondCity/contribute
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details open>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: bright eyes works on non-werewolves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
